### PR TITLE
fix AddonBuilder 'unable to open directory lib'

### DIFF
--- a/io/Eerie/AddonBuilder.io
+++ b/io/Eerie/AddonBuilder.io
@@ -253,7 +253,9 @@ AddonBuilder := Object clone do(
 
   includePaths := method(
     includePaths := List clone
-    includePaths appendSeq(libsFolder directories map(path) map(p, Path with(p, "_build/headers")))
+    if(libsFolder exists,
+      includePaths appendSeq(libsFolder directories map(path) map(p, Path with(p, "_build/headers")))
+    )
     includePaths appendSeq(depends addons map(n, (Eerie usedEnv path) .. "/addons/" .. n .. "/_build/headers"))
     includePaths
   )


### PR DESCRIPTION
Looks like API of `Directory` has changed so if there is no any directory at a path, `directories` method raises an exception. The patch is checking if the `libs` directory exists before adding it to include paths.